### PR TITLE
Add pause/resume control to log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a small GUI application for viewing log files as they are written. It is
 * Select a log file from a file dialog.
 * Display existing log content and automatically append new lines as they are written.
 * Continue streaming until you select a new file or close the program.
+* Pause and resume streaming so you can examine the log without new lines
+  shifting the view.
 
 ## Requirements
 * Python 3.8 or newer (with Tkinter, included in standard Python installers).
@@ -25,3 +27,9 @@ pyinstaller --onefile --windowed log_viewer.py
 ```
 
 The executable will be placed in the `dist` directory.
+
+## Pausing Streaming
+Use the **Pause** button at the bottom of the window to temporarily stop reading
+the active log file. This allows you to scroll and inspect previous lines
+without new log entries moving the view. Click **Resume** to continue streaming
+from the point where you paused.


### PR DESCRIPTION
## Summary
- add a pause button to pause/resume streaming
- allow toggling with `Resume` label when paused
- document new pause/resume feature

## Testing
- `python -m py_compile log_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_687012c3cf24832189fc243e0ae2f8c3