### PR TITLE
Improve log loading behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This is a small GUI application for viewing log files as they are written. It is
 ## Features
 * Select a log file from a file dialog.
 * Display log content with the newest lines at the top of the window.
-* Automatically stream new lines as they are written while older entries load lazily.
+* Initially load roughly the last 100 lines and lazily load older entries below
+  without shifting the view.
+* Automatically stream new lines at the top as they arrive.
 * Continue streaming until you select a new file or close the program.
 * Pause and resume streaming so you can inspect the log without new lines
   shifting the view.

--- a/log_viewer.py
+++ b/log_viewer.py
@@ -32,7 +32,8 @@ class LogViewer(tk.Tk):
         self.history_thread = None
         self.history_file = None
         self.history_pos = 0
-        self.initial_lines = 200
+        # Load roughly 100 recent lines first
+        self.initial_lines = 100
         self.history_chunk_lines = 500
         self.filepath = None
 
@@ -124,9 +125,11 @@ class LogViewer(tk.Tk):
         self.text_area.configure(state='disabled')
 
     def _insert_bottom(self, text):
+        # Preserve the current view position while inserting at the end
         self.text_area.configure(state='normal')
+        yview = self.text_area.yview()
         self.text_area.insert(tk.END, text)
-        self.text_area.see(tk.END)
+        self.text_area.yview_moveto(yview[0])
         self.text_area.configure(state='disabled')
 
     def _read_last_lines(self, filepath, num_lines=100, chunk_size=4096):


### PR DESCRIPTION
## Summary
- load roughly 100 recent log lines initially
- keep scroll position when loading older history
- document lazy loading behavior

## Testing
- `python -m py_compile log_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_687024b6a72483218fd3f96f55f7c387